### PR TITLE
Add component's name into bower.json (necessary to run bower install)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,5 @@
 {
+    "name": "less-interop",
     "private": true,
     "dependencies": {
         "polymer": "Polymer/polymer#~0.3.3"


### PR DESCRIPTION
The component's name is missed and it's necessary to run `bower install`
